### PR TITLE
Change misspelled tag: 'foot_way'->'footway'

### DIFF
--- a/src/osm4routing/categorize.rs
+++ b/src/osm4routing/categorize.rs
@@ -96,7 +96,7 @@ impl EdgeProperties {
         match key {
             "highway" => {
                 match val {
-                    "cycleway" | "path" | "foot_way" | "steps" | "pedestrian" => {
+                    "cycleway" | "path" | "footway" | "steps" | "pedestrian" => {
                         self.bike_forward = BIKE_TRACK;
                         self.foot = FOOT_ALLOWED;
                     }


### PR DESCRIPTION
This PR fixes the absence of `highway=footway` ways in the output due to the misspelled `foot_way` tag.