### PR TITLE
Replace deprecated try! with ?

### DIFF
--- a/src/osm4routing/reader.rs
+++ b/src/osm4routing/reader.rs
@@ -140,9 +140,9 @@ impl Reader {
 pub fn read(filename: &str) -> Result<(Vec<Node>, Vec<Edge>), String> {
     let mut r = Reader::new();
     let path = std::path::Path::new(filename);
-    let file = try!(std::fs::File::open(&path).map_err(|e| e.to_string()));
+    let file = std::fs::File::open(&path).map_err(|e| e.to_string())?;
     r.read_ways(file);
-    let file_nodes = try!(std::fs::File::open(&path).map_err(|e| e.to_string()));
+    let file_nodes = std::fs::File::open(&path).map_err(|e| e.to_string())?;
     r.read_nodes(file_nodes);
     r.count_nodes_uses();
     let edges = r.edges();


### PR DESCRIPTION
As of 1.39, the `try!` macro is [deprecated](https://github.com/rust-lang/rust/pull/62672)
